### PR TITLE
Refactor Release Workflow to Date-based Tagging and Automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - '*'
   workflow_dispatch:
 
 jobs:
@@ -31,4 +31,4 @@ jobs:
           name: plotnikau/tube2pod
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PWD }}
-          tag_semver: true
+          tags: "${{ github.ref_name }},latest"

--- a/.github/workflows/update-go-deps.yml
+++ b/.github/workflows/update-go-deps.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   update-deps:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -32,11 +35,14 @@ jobs:
       - name: Set tag
         id: set_tag
         run: |
-          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          echo $latest_tag
-          IFS='.' read -r major minor patch <<<"${latest_tag#v}"
-          new_patch=$((patch + 1))
-          new_tag="v${major}.${minor}.${new_patch}"
+          new_tag=$(date -u +'%Y-%m-%d-%H%M')
+          echo "New tag: $new_tag"
           git tag "$new_tag"
           git push origin "$new_tag"
-          echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+          echo "VERSION=$new_tag" >> $GITHUB_OUTPUT
+
+      - name: Trigger Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml --ref ${{ steps.set_tag.outputs.VERSION }}


### PR DESCRIPTION
This change refactors the GitHub workflows to meet the new release requirements. The tagging process now uses a date-based format (`YYYY-MM-DD-HHMM`) without a `v` prefix. The tagging workflow (`update-go-deps.yml`) now automatically triggers the release workflow (`release.yml`) upon success. Additionally, the Docker image is now tagged with both the specific date-based version and the `latest` tag.

---
*PR created automatically by Jules for task [3185618024332952376](https://jules.google.com/task/3185618024332952376) started by @plotnikau*