### PR TITLE
Add YouTube thumbnails to audio files

### DIFF
--- a/internal/app/constants.go
+++ b/internal/app/constants.go
@@ -4,6 +4,7 @@ const (
 	TmpDir   = "./tmp/"
 	ExtAudio = ".mp3"
 	ExtVideo = ".mp4"
+	ExtThumb = ".jpg"
 )
 
 const (

--- a/internal/app/integration_test.go
+++ b/internal/app/integration_test.go
@@ -27,7 +27,7 @@ func TestFullWorkflow_Integration(t *testing.T) {
 	// 1. Download
 	sentMsg1 := &tb.Message{ID: 100, Text: "*Download* ...", Chat: chat}
 	mockBot.On("Send", sender, "*Download* ...", mock.Anything).Return(sentMsg1, nil)
-	mockDownloader.On("Download", mock.Anything, message.Text).Return(true, "Title", "VideoID")
+	mockDownloader.On("Download", mock.Anything, message.Text).Return(true, "Title", "VideoID", "ThumbPath")
 	mockBot.On("Delete", message).Return(nil)
 
 	// 2. Convert & 3. Delivery (Multiple Edit calls)

--- a/internal/app/interfaces.go
+++ b/internal/app/interfaces.go
@@ -7,7 +7,7 @@ import (
 
 // Downloader defines the interface for downloading videos.
 type Downloader interface {
-	Download(ctx context.Context, url string) (success bool, title string, id string)
+	Download(ctx context.Context, url string) (success bool, title string, id string, thumb string)
 }
 
 // Converter defines the interface for extracting audio from video files.

--- a/internal/app/processor_test.go
+++ b/internal/app/processor_test.go
@@ -12,9 +12,9 @@ type MockDownloader struct {
 	mock.Mock
 }
 
-func (m *MockDownloader) Download(ctx context.Context, url string) (bool, string, string) {
+func (m *MockDownloader) Download(ctx context.Context, url string) (bool, string, string, string) {
 	args := m.Called(ctx, url)
-	return args.Bool(0), args.String(1), args.String(2)
+	return args.Bool(0), args.String(1), args.String(2), args.String(3)
 }
 
 type MockConverter struct {
@@ -84,7 +84,7 @@ func TestHandleDownload_Success(t *testing.T) {
 
 	sentMsg := &tb.Message{Text: "*Download* ..."}
 	mockBot.On("Send", sender, "*Download* ...", mock.Anything).Return(sentMsg, nil)
-	mockDownloader.On("Download", mock.Anything, task.URL).Return(true, "Title", "VideoID")
+	mockDownloader.On("Download", mock.Anything, task.URL).Return(true, "Title", "VideoID", "ThumbPath")
 	mockBot.On("Delete", message).Return(nil)
 
 	// We need to capture the output channel to prevent blocking
@@ -98,6 +98,9 @@ func TestHandleDownload_Success(t *testing.T) {
 	}
 	if receivedTask.Title != "Title" {
 		t.Errorf("Expected Title, got %s", receivedTask.Title)
+	}
+	if receivedTask.ThumbnailPath != "ThumbPath" {
+		t.Errorf("Expected ThumbPath, got %s", receivedTask.ThumbnailPath)
 	}
 
 	mockBot.AssertExpectations(t)

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -11,3 +11,7 @@ func GetAudioFilenamePattern(id string) string {
 func GetVideoFilename(id string) string {
 	return TmpDir + id + ExtVideo
 }
+
+func GetThumbnailFilename(id string) string {
+	return TmpDir + id + ExtThumb
+}

--- a/internal/platform/downloader.go
+++ b/internal/platform/downloader.go
@@ -3,7 +3,9 @@ package platform
 import (
 	"context"
 	"io"
+	"net/http"
 	"os"
+	"os/exec"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/wader/goutubedl"
@@ -12,13 +14,13 @@ import (
 
 type YoutubeDownloader struct{}
 
-func (y *YoutubeDownloader) Download(ctx context.Context, url string) (success bool, title string, id string) {
+func (y *YoutubeDownloader) Download(ctx context.Context, url string) (success bool, title string, id string, thumb string) {
 	log.Info("starting download")
 
 	result, err := goutubedl.New(ctx, url, goutubedl.Options{})
 	if err != nil {
 		log.Error("Failed to get video info", err)
-		return false, app.Empty, app.Empty
+		return false, app.Empty, app.Empty, app.Empty
 	}
 
 	title = result.Info.Title
@@ -26,21 +28,68 @@ func (y *YoutubeDownloader) Download(ctx context.Context, url string) (success b
 	fileId := result.Info.ID
 	filename := app.GetVideoFilename(fileId)
 
+	// Download thumbnail
+	thumb = app.Empty
+	if result.Info.Thumbnail != "" {
+		thumb = y.downloadAndResizeThumbnail(result.Info.Thumbnail, fileId)
+	}
+
 	downloadResult, err := result.Download(ctx, "bestaudio")
 	if err != nil {
 		log.Error("Failed to download video", err)
-		return false, app.Empty, app.Empty
+		return false, app.Empty, app.Empty, app.Empty
 	}
 	defer downloadResult.Close()
 	f, err := os.Create(filename)
 	if err != nil {
 		log.Error("Failed to save downloaded video to file")
-		return false, app.Empty, app.Empty
+		return false, app.Empty, app.Empty, app.Empty
 	}
 	defer f.Close()
 	io.Copy(f, downloadResult)
 
 	log.Debug("==> Video done")
 
-	return true, title, fileId
+	return true, title, fileId, thumb
+}
+
+func (y *YoutubeDownloader) downloadAndResizeThumbnail(url string, id string) string {
+	log.Debug("==> Downloading thumbnail: ", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Error("Failed to download thumbnail: ", err)
+		return app.Empty
+	}
+	defer resp.Body.Close()
+
+	tempThumb := app.TmpDir + id + "_raw"
+	f, err := os.Create(tempThumb)
+	if err != nil {
+		log.Error("Failed to create temp thumbnail file: ", err)
+		return app.Empty
+	}
+	defer os.Remove(tempThumb)
+
+	_, err = io.Copy(f, resp.Body)
+	f.Close()
+	if err != nil {
+		log.Error("Failed to save temp thumbnail: ", err)
+		return app.Empty
+	}
+
+	thumbPath := app.GetThumbnailFilename(id)
+	ffmpeg, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		log.Error("ffmpeg not found for thumbnail resizing")
+		return app.Empty
+	}
+
+	// Resize to 320x320 max while keeping aspect ratio, and convert to jpg
+	cmd := exec.Command(ffmpeg, "-y", "-loglevel", "quiet", "-i", tempThumb, "-vf", "scale='if(gt(a,1),320,-1)':'if(gt(a,1),-1,320)'", thumbPath)
+	if err := cmd.Run(); err != nil {
+		log.Error("Failed to resize thumbnail with ffmpeg: ", err)
+		return app.Empty
+	}
+
+	return thumbPath
 }


### PR DESCRIPTION
Added YouTube thumbnail support for audio files sent by the bot. Thumbnails are resized with ffmpeg to 320x320 and attached to the Telegram audio messages. Cleanup is handled after the audio is sent.

---
*PR created automatically by Jules for task [9768456028814473621](https://jules.google.com/task/9768456028814473621) started by @plotnikau*