### PR TITLE
Implement automatic SponsorBlock removal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Welcome, fellow agent! This project is a Telegram bot that converts YouTube vide
     - `TELEGRAM_BOT_TOKEN`: Required for the bot to start.
 
 ## Recent Changes
+- Implemented SponsorBlock removal for the `sponsor` category. This is achieved via a `yt-dlp` wrapper script in the Docker image that injects the `--sponsorblock-remove sponsor` flag.
 - Removed Archive.org integration (it was deemed obsolete). The bot now focuses purely on Telegram delivery.
 - Updated documentation and added this `AGENTS.md` file.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,10 @@ RUN set -x && \
         && \
     git config --global advice.detachedHead false && \
     # Install yt-dlp via curl
-    curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp && \
+    curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp-real && \
+    chmod a+x /usr/local/bin/yt-dlp-real && \
+    # Create wrapper for yt-dlp to inject SponsorBlock removal
+    printf '#!/bin/bash\nexec /usr/local/bin/yt-dlp-real --sponsorblock-remove sponsor "$@"\n' > /usr/local/bin/yt-dlp && \
     chmod a+x /usr/local/bin/yt-dlp && \
     # Create /config directory
     mkdir -p /config && \

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ Hey there! **tube2pod** is a friendly Telegram bot that turns YouTube videos int
 ## ✨ Features
 - **Easy Peasy**: Just send a YouTube link, and the bot does the rest.
 - **Auto-Split**: Large videos are automatically split into 45-minute chunks so they're easy to handle in Telegram.
+- **SponsorBlock**: Automatically removes sponsored segments from videos during download.
 - **Fast & Reliable**: Powered by `yt-dlp` and `ffmpeg` for high-quality audio extraction.
 - **Docker Ready**: Super simple to host yourself.
 


### PR DESCRIPTION
Implemented automatic SponsorBlock removal (sponsor category) using a yt-dlp wrapper script in the Docker image. Always enabled by default.

---
*PR created automatically by Jules for task [3585471351699839215](https://jules.google.com/task/3585471351699839215) started by @plotnikau*